### PR TITLE
Add customCljsRepl to vscode worfkspace settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+    "calva.customCljsRepl": {
+        "name": "nREPL hot reload",
+        "startCode": "(cljs-repl)",
+        "connectedRegExp": "To quit, type: :cljs/quit"
+    }
+}


### PR DESCRIPTION
Since this project starts Figwheel Main itself, Calva needs to be told how to start the cljs repl. This PR adds a custom cljs setting to the workspace with the code to start the repl at connect time.

NB: Calva does not yet support this scenario for Jack in. So you will need to start the repl manually in a terminal and then tell Calva to connect (default keybindings `ctrl+alt+c ctrl+alt+c`).

I am not sure this is enough to make Calva work with your setup, but please try it out and let me know how you fare.

Addressing https://github.com/BetterThanTomorrow/calva/issues/276